### PR TITLE
a11y: enforce WCAG AA contrast in both themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.59.1",
         "knip": "^6.18.0",
         "playwright": "^1.59.1",
@@ -201,6 +202,19 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2595,6 +2609,16 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.59.1",
     "knip": "^6.18.0",
     "playwright": "^1.59.1",

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -435,17 +435,18 @@ import CloudMarquee from "../components/CloudMarquee.astro";
     .fof-home {
       font-family: var(--font-mono);
       font-size: clamp(0.75rem, 1.1vw, 0.95rem);
-      color: var(--fg);
+      /* --muted is the de-emphasis token and meets WCAG AA in both themes;
+         the previous color:var(--fg) + opacity:0.4 rendered at ~3.3:1 (issue #22). */
+      color: var(--muted);
       text-decoration: none;
-      opacity: 0.4;
-      transition: opacity 0.2s, border-color 0.2s;
+      transition: color 0.2s, border-color 0.2s;
       letter-spacing: 0.05em;
       border: 1px solid transparent;
       padding: 0.3em 0.6em;
     }
 
     .fof-home:hover {
-      opacity: 0.9;
+      color: var(--fg);
       border-color: var(--cloud);
     }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,11 @@
 */
 
 :root {
-  /* High-contrast Terminal Aesthetic */
+  /* High-contrast Terminal Aesthetic.
+     Text pairings meet WCAG AA in both themes (4.5:1 body / 3:1 large):
+     --fg and --muted on --bg both pass; --cloud is a decorative/border tone,
+     not a text color. Enforced by tests/contrast.spec.ts (axe-core, both themes).
+     Do not de-emphasize text with low opacity — use --muted instead. */
   --bg: #f5f3ec;
   --fg: #1a1a1a;
   --cloud: #d5d3cc;

--- a/tests/contrast.spec.ts
+++ b/tests/contrast.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// WCAG AA color-contrast audit (issue #22). Runs axe-core's color-contrast rule
+// against representative pages in both themes. The 6-token color system lives in
+// src/styles/global.css; this test is the guard that keeps every text/background
+// pairing at AA as those tokens evolve.
+
+const PAGES = [
+  '/',
+  '/about',
+  '/cv',
+  '/blog',
+  '/blog/ai-a-retrospective-part-2', // a representative blog post
+  '/404',
+];
+
+const THEMES = ['light', 'dark'] as const;
+
+for (const theme of THEMES) {
+  for (const path of PAGES) {
+    test(`contrast AA — ${theme} — ${path}`, async ({ page }) => {
+      // Set the persisted theme before the page's inline theme script runs.
+      await page.addInitScript((t) => {
+        try {
+          localStorage.setItem('blog-theme', t);
+        } catch {
+          /* storage may be unavailable */
+        }
+      }, theme);
+
+      await page.goto(path, { waitUntil: 'networkidle' });
+      await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+
+      const results = await new AxeBuilder({ page })
+        .withRules(['color-contrast'])
+        .analyze();
+
+      const violations = results.violations.flatMap((v) =>
+        v.nodes.map((n) => `${n.target.join(' ')} — ${n.failureSummary?.split('\n').pop()?.trim()}`)
+      );
+      expect(violations, violations.join('\n')).toEqual([]);
+    });
+  }
+}


### PR DESCRIPTION
Adds an axe-core color-contrast audit (`tests/contrast.spec.ts`) across 6 representative pages × light/dark — it runs in the chromium CI gate, so contrast regressions now block merge.

Caught and fixed one real failure: `.fof-home` on /404 used `color:var(--fg)` at `opacity:0.4` (~3.3:1). Switched to `var(--muted)` (AA in both themes), brightening to `--fg` on hover — also brings it back onto the 6-token system. Documented the AA stance + no-low-opacity-text rule in `global.css`.

Verified: 12/12 contrast checks pass; full chromium suite 61 passed; verify:local green.

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved 404 page link styling for better color contrast compliance.

* **Tests**
  * Added automated color contrast validation across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->