### PR TITLE
perf: trim dead CSS in cv.astro (audit #19)

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1312,9 +1312,6 @@ const jsonLd = JSON.stringify({
     }
 
     /* Summary */
-    .cv-summary-block {
-      margin-bottom: 8pt !important;
-    }
     .cv-summary {
       font-size: 9.1pt !important;
       line-height: 1.45 !important;


### PR DESCRIPTION
Audit of 404.astro + cv.astro for dead code (#19).

**Finding:** these pages aren't bloated with dead code. The markup is clean (no commented-out blocks), and class-usage analysis flagged exactly one orphaned rule.

**Removed:** `.cv-summary-block` (defined, referenced nowhere).

**Kept (verified in-use):** `:global()` selectors targeting layout (nav/footer/oliv/page-content) in both files, all screen + print rules. cv.astro's size is a 912-line legitimate screen+print stylesheet; 404.astro's is the snake canvas + ASCII.

**Out of scope:** deeper size reduction = CSS consolidation (#15), separate/riskier.

Verified: 404.spec, cv-pages, cv-print all pass; full chromium suite 61 passed; verify:local green; CSS-only removal so visual parity is guaranteed.

Closes #19