### PR TITLE
build(deps): bump playwright 1.59→1.61 + @chenglou/pretext 0.0.4→0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
-        "@chenglou/pretext": "^0.0.4",
+        "@chenglou/pretext": "^0.0.8",
         "@fontsource-variable/recursive": "^5.2.8",
         "astro": "^6.1.4",
         "textlens": "^1.0.11",
@@ -21,9 +21,9 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.61.0",
         "knip": "^6.18.0",
-        "playwright": "^1.59.1",
+        "playwright": "^1.61.0",
         "sharp": "^0.35.2",
         "unist-util-visit": "^5.1.0"
       },
@@ -266,7 +266,9 @@
       }
     },
     "node_modules/@chenglou/pretext": {
-      "version": "0.0.4",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
       "license": "MIT"
     },
     "node_modules/@clack/core": {
@@ -1623,11 +1625,13 @@
       ]
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3323,6 +3327,20 @@
       },
       "engines": {
         "node": ">=18.3.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5104,11 +5122,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5121,7 +5141,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6292,6 +6314,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vitefu": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
-    "@chenglou/pretext": "^0.0.4",
+    "@chenglou/pretext": "^0.0.8",
     "@fontsource-variable/recursive": "^5.2.8",
     "astro": "^6.1.4",
     "textlens": "^1.0.11",
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.61.0",
     "knip": "^6.18.0",
-    "playwright": "^1.59.1",
+    "playwright": "^1.61.0",
     "sharp": "^0.35.2",
     "unist-util-visit": "^5.1.0"
   },


### PR DESCRIPTION
Consolidates three Dependabot bumps into one verified change:

- `playwright` 1.59.1 → 1.61.0 (dev)
- `@playwright/test` 1.59.1 → 1.61.0 (dev)
- `@chenglou/pretext` 0.0.4 → 0.0.8

Local validation: `verify:local` green; chromium smoke **61/61** pass.

Supersedes #55, #56, #57.