### PR TITLE
build(deps): bump typescript 5.9.3 → 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fontsource-variable/recursive": "^5.2.8",
         "astro": "^6.1.4",
         "textlens": "^1.0.11",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
@@ -2613,6 +2613,42 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/astro/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/astro/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/axe-core": {
@@ -5873,24 +5909,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5903,7 +5921,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@fontsource-variable/recursive": "^5.2.8",
     "astro": "^6.1.4",
     "textlens": "^1.0.11",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/src/components/DotBlogAI.astro
+++ b/src/components/DotBlogAI.astro
@@ -148,7 +148,7 @@ const endpoint = "https://dotblogai.dotmavriq-6d3.workers.dev";
       return message;
     };
 
-    launch.addEventListener("click", () => setOpen(panel.hidden), { signal });
+    launch.addEventListener("click", () => setOpen(Boolean(panel.hidden)), { signal });
     close.addEventListener("click", () => setOpen(false), { signal });
 
     const olivThemeToggle = document.getElementById("oliv-theme-toggle") as HTMLButtonElement | null;


### PR DESCRIPTION
Major bump to TypeScript 6.

**Code change required:** TS 6 narrows `HTMLElement.hidden` to `boolean | "until-found"`, so `setOpen(panel.hidden)` in `DotBlogAI.astro` no longer satisfies the `boolean` parameter. Wrapped in `Boolean()` — same runtime behavior.

Local validation: `verify:local` green (`astro check` 0 errors); chromium smoke **61/61** pass.

Supersedes #54.