### PR TITLE
perf(StructuralArt): pause cityscape rAF off-screen + fix orphaned loops

### DIFF
--- a/src/components/StructuralArt.astro
+++ b/src/components/StructuralArt.astro
@@ -27,18 +27,16 @@
     return intervals;
   }
 
-  let prevStructuralRaf: number | null = null;
-  let prevStructuralRo: ResizeObserver | null = null;
-  let prevStructuralMq: MediaQueryList | null = null;
-  let prevStructuralMqHandler: (() => void) | null = null;
+  // Full teardown of the previous instance. ClientRouter re-runs init on every
+  // navigation, so this must actually stop the live loop and observers —
+  // cancelling a snapshotted rafId did not (the loop reassigns it each frame),
+  // which orphaned a forever-running loop per navigation.
+  let prevStructuralCleanup: (() => void) | null = null;
 
   function initStructuralArt() {
-    if (prevStructuralRaf) cancelAnimationFrame(prevStructuralRaf);
-    if (prevStructuralRo) prevStructuralRo.disconnect();
-    if (prevStructuralMq && prevStructuralMqHandler) {
-      prevStructuralMq.removeEventListener("change", prevStructuralMqHandler);
-      prevStructuralMq = null;
-      prevStructuralMqHandler = null;
+    if (prevStructuralCleanup) {
+      prevStructuralCleanup();
+      prevStructuralCleanup = null;
     }
 
     const sceneEl = document.getElementById("ascii-scene");
@@ -162,6 +160,12 @@
     let frame = 0;
     let rafId = 0;
     let charW = 0;
+    // Animation gating: the rAF loop only runs in animated mode (desktop, motion
+    // allowed) AND while the backdrop is actually on screen. Scrolling it fully
+    // out of view pauses rendering so it doesn't burn CPU/battery off-screen.
+    let animatedMode = false;
+    let onscreen = true;
+    let disposed = false;
     let charH = 0;
 
     // ── Per-resize caches ───────────────────────────────────────────
@@ -447,18 +451,35 @@
 
       scene.textContent = buffer.map(row => row.join("")).join("\n");
       frame++;
-      rafId = requestAnimationFrame(render);
+      // Keep looping only while alive and on screen; otherwise idle until the
+      // IntersectionObserver resumes us. Avoids a runaway off-screen loop.
+      rafId = (!disposed && onscreen) ? requestAnimationFrame(render) : 0;
+    }
+
+    function startLoop() {
+      if (animatedMode && onscreen && !disposed && !rafId) {
+        rafId = requestAnimationFrame(render);
+      }
+    }
+
+    function stopLoop() {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = 0;
+      }
     }
 
     function init() {
       measure();
-      if (rafId) cancelAnimationFrame(rafId);
+      stopLoop();
       frame = 0;
       // Render a single static frame when the user prefers reduced motion OR
       // on mobile (≤768px). The continuous rAF loop behind the /social feed is
       // a major source of mobile jank/crashing, so phones get a still backdrop.
       if (window.matchMedia("(prefers-reduced-motion: reduce)").matches || compactMq.matches) {
         // Static render with organic edges
+        animatedMode = false;
+        stopLoop();
         const buf: string[][] = [];
         for (let r = 0; r < H; r++) buf.push(buildRow(r, H, W));
         if (!compactMq.matches) {
@@ -467,7 +488,8 @@
         }
         scene.textContent = buf.map(row => row.join("")).join("\n");
       } else {
-        rafId = requestAnimationFrame(render);
+        animatedMode = true;
+        startLoop();
       }
     }
 
@@ -480,18 +502,32 @@
     });
     ro.observe(wrapper);
     if (obstacle) ro.observe(obstacle);
-    prevStructuralRo = ro;
+
+    // Pause the animation loop whenever the backdrop is fully scrolled out of
+    // view, and resume on re-entry. Near-zero CPU when off-screen; only matters
+    // in animated mode (mobile/reduced-motion are static and never start it).
+    const io = new IntersectionObserver((entries) => {
+      onscreen = entries.some((e) => e.isIntersecting);
+      if (onscreen) startLoop();
+      else stopLoop();
+    });
+    io.observe(wrapper);
     // Re-run init() (not just measure) on the 768px boundary so the rAF loop
     // is started/stopped when crossing between mobile and desktop.
     const compactHandler = () => {
       init();
     };
     compactMq.addEventListener("change", compactHandler);
-    prevStructuralMq = compactMq;
-    prevStructuralMqHandler = compactHandler;
+
+    prevStructuralCleanup = () => {
+      disposed = true;
+      stopLoop();
+      ro.disconnect();
+      io.disconnect();
+      compactMq.removeEventListener("change", compactHandler);
+    };
 
     init();
-    prevStructuralRaf = rafId;
     }
   }
 

--- a/tests/cityscape-perf.spec.ts
+++ b/tests/cityscape-perf.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// Desktop + motion allowed: the ASCII cityscape animates (its #ascii-scene
+// textContent changes each frame). Scrolling it fully off screen must pause the
+// loop so the content stops changing; bringing it back must resume it.
+test('cityscape pauses when off screen and resumes on return', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/');
+
+  const scene = page.locator('#ascii-scene');
+  await expect(scene).toBeVisible();
+  const snap = () => scene.evaluate((el) => el.textContent ?? '');
+
+  // On screen → animating.
+  const a = await snap();
+  await page.waitForTimeout(500);
+  const b = await snap();
+  expect(b, 'should animate while on screen').not.toBe(a);
+
+  // Off screen → paused (content frozen).
+  await page.evaluate(() => {
+    const w = document.getElementById('ascii-scene')?.parentElement as HTMLElement | null;
+    if (w) { w.style.position = 'fixed'; w.style.top = '-5000px'; w.style.left = '0'; w.style.height = '300px'; w.style.width = '300px'; }
+  });
+  await page.waitForTimeout(500);
+  const c = await snap();
+  await page.waitForTimeout(500);
+  const d = await snap();
+  expect(d, 'should be frozen while off screen').toBe(c);
+
+  // Back on screen → resumes.
+  await page.evaluate(() => {
+    const w = document.getElementById('ascii-scene')?.parentElement as HTMLElement | null;
+    if (w) { w.style.removeProperty('position'); w.style.removeProperty('top'); w.style.removeProperty('left'); w.style.removeProperty('height'); w.style.removeProperty('width'); }
+  });
+  await page.waitForTimeout(500);
+  const e = await snap();
+  await page.waitForTimeout(500);
+  const f = await snap();
+  expect(f, 'should resume animating after returning on screen').not.toBe(e);
+});


### PR DESCRIPTION
Addresses the code-fixable parts of #20 (cityscape mobile/perf).

## Two fixes
**1. Off-screen pause (the acceptance item "CPU drops to near-zero when off screen — IntersectionObserver pause if not already").**
The desktop rAF loop ran continuously even when the cityscape was scrolled out of view. An IntersectionObserver now stops the loop when the backdrop is fully off-screen and resumes it on re-entry.

**2. Orphaned-loop fix (a real pre-existing perf bug I found while doing #1).**
The site uses `<ClientRouter />`, so `initStructuralArt` re-runs on every navigation. Teardown cancelled a *snapshotted* `rafId` — but the loop reassigns `rafId` every frame, so the prior loop was never actually cancelled. **Every SPA navigation leaked a forever-running rAF loop.** Replaced the snapshot cleanup with a proper teardown closure (`disposed` flag + `stopLoop()` + observer `disconnect()`).

## Already handled (verified, no change needed)
- `prefers-reduced-motion: reduce` → static render, no loop.
- **Mobile ≤768px → static backdrop, no rAF at all** (the main mobile-jank concern was already solved).
- CLS guarded via `min-height` on `.structural-art`.

## Verification
- New regression test `tests/cityscape-perf.spec.ts`: asserts the scene animates on screen, **freezes off screen**, and resumes on return.
- Full chromium suite: **62/62**. `verify:local`: 0 errors, bundle 93.9 KB (under budget).

## Remaining manual item on #20
Profiling on a physical mid-range Android — needs your device, can't be automated here.

Refs #20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Animation now properly pauses when scrolled out of view and resumes when visible again.
  * Improved cleanup during page navigation to prevent orphaned animation loops.
  * Enhanced support for reduced-motion preferences and mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->