### PR TITLE
chore: add issue/PR templates and document label scheme

### DIFF
--- a/.github/ISSUE_TEMPLATE/a11y.md
+++ b/.github/ISSUE_TEMPLATE/a11y.md
@@ -1,0 +1,18 @@
+---
+name: Accessibility (a11y)
+about: A barrier to access — contrast, semantics, keyboard, motion, assistive tech
+title: "a11y: "
+labels: accessibility
+---
+
+## Barrier
+<!-- What's inaccessible and who it affects. -->
+
+## Where
+<!-- Page(s) / component(s). -->
+
+## Expected behavior
+<!-- e.g. WCAG AA contrast, focus order, reduced-motion honored, <pre> aria-hidden. -->
+
+## How to verify
+<!-- Tooling (axe, contrast check) or manual steps. -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+---
+name: Bug
+about: Something renders, builds, or behaves incorrectly
+title: "bug: "
+labels: bug
+---
+
+## What's wrong
+<!-- Clear description of the incorrect behavior. -->
+
+## Steps to reproduce
+1.
+2.
+
+## Expected vs actual
+- Expected:
+- Actual:
+
+## Environment
+<!-- Browser / device / viewport; or "CI" / "local build". -->
+
+## Notes
+<!-- Screenshots, console output, suspected file(s). -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,16 @@
+---
+name: Chore
+about: Tooling, CI, dependencies, repo housekeeping — no user-facing change
+title: "chore: "
+labels: chore
+---
+
+## Task
+<!-- What needs doing and why now. -->
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Notes
+<!-- Affected config/scripts/workflows; risks; rollback. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Operating contract & backlog
+    url: https://github.com/dotMavriQ/blog.dotmavriq/blob/main/docs/PRODUCTION_READINESS.md
+    about: Read the production-readiness manual (locked decisions, CI gates, invariants) before filing structural work.

--- a/.github/ISSUE_TEMPLATE/content.md
+++ b/.github/ISSUE_TEMPLATE/content.md
@@ -1,0 +1,16 @@
+---
+name: Content
+about: Blog posts and prose — corrections, dead links, new/updated writing
+title: "content: "
+labels: content
+---
+
+## What
+<!-- The post(s) affected and the change needed. -->
+
+## Details
+<!-- Correction, dead/broken link, fact-check, new piece, etc. -->
+
+## Notes
+<!-- Post bodies (src/content/blog/*.md) are hand-written and owned by the author
+     during the curation window — see CONTRIBUTING.md "Content fast-path". -->

--- a/.github/ISSUE_TEMPLATE/feat.md
+++ b/.github/ISSUE_TEMPLATE/feat.md
@@ -1,0 +1,20 @@
+---
+name: Feature / enhancement
+about: A new capability or an improvement to an existing one
+title: "feat: "
+labels: enhancement
+---
+
+## Problem / motivation
+<!-- What's missing or awkward today, and why it matters. -->
+
+## Proposed change
+<!-- What should exist. Keep it within the structural invariants
+     (docs/PRODUCTION_READINESS.md) unless explicitly flagged. -->
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Out of scope
+<!-- Anything deliberately excluded. -->

--- a/.github/ISSUE_TEMPLATE/perf.md
+++ b/.github/ISSUE_TEMPLATE/perf.md
@@ -1,0 +1,18 @@
+---
+name: Performance
+about: Page weight, runtime cost, jank, battery, or Lighthouse regressions
+title: "perf: "
+labels: performance
+---
+
+## Symptom
+<!-- What's slow/heavy and where it's observed. -->
+
+## Measurement
+<!-- Numbers if you have them: Lighthouse metric, bundle KB, CPU/frame, device. -->
+
+## Budget / target
+<!-- The threshold this should meet (see lighthouserc.json / guard:bundle). -->
+
+## Notes
+<!-- Suspected cause, offscreen behavior, reduced-motion interplay. -->

--- a/.github/ISSUE_TEMPLATE/seo.md
+++ b/.github/ISSUE_TEMPLATE/seo.md
@@ -1,0 +1,18 @@
+---
+name: SEO / AEO
+about: Metadata, structured data, sitemap, feeds, crawlability, answer-engine surfacing
+title: "seo: "
+labels: seo
+---
+
+## Issue
+<!-- What's missing or incorrect for search/answer engines. -->
+
+## Where
+<!-- Page(s), template, feed, or sitemap. -->
+
+## Expected
+<!-- e.g. canonical, OG/meta, <lastmod>, valid feed, JSON-LD. -->
+
+## How to verify
+<!-- Validator, view-source, or built-artifact check. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Title: use a conventional prefix matching the change type, e.g.
+     feat: / bug: / chore: / ci: / a11y: / seo: / perf: / content: / refactor: -->
+
+## Summary
+<!-- What changed and why. One or two sentences is fine. -->
+
+## Test plan
+<!-- How you verified it. Mirror the gates that apply:
+     npm run verify:local · npx playwright test --project=chromium · manual check. -->
+- [ ] `npm run verify:local` green
+- [ ] Smoke tests pass (`npx playwright test --project=chromium`)
+- [ ]
+
+## Related issues
+<!-- "Closes #NN" / "Refs #NN". -->
+
+---
+<!-- Reminder: plain commit messages, no AI/tool attribution trailers (CONTRIBUTING.md). -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,26 @@ During the curation window they may be pushed directly and are excluded from AI
 review. Everything else (components, layouts, scripts, config, CI) goes through a
 PR.
 
+## Issue & PR templates, labels
+
+New issues pick a type from `.github/ISSUE_TEMPLATE/`; each applies its label and
+a matching title prefix. PRs use `.github/PULL_REQUEST_TEMPLATE.md` (summary,
+test plan, related issues). The same vocabulary is used for the title prefix, the
+branch name (`<type>/<short-description>`), and the commit subject, so a change
+reads the same from issue to branch to PR to log.
+
+| Type | Label | Prefix | For |
+|------|-------|--------|-----|
+| Feature | `enhancement` | `feat:` | New capability or improvement |
+| Bug | `bug` | `bug:` | Incorrect render/build/behavior |
+| Chore | `chore` | `chore:` | Tooling, CI, deps, housekeeping |
+| Accessibility | `accessibility` | `a11y:` | Contrast, semantics, keyboard, motion |
+| Performance | `performance` | `perf:` | Page weight, runtime cost, jank, budgets |
+| SEO/AEO | `seo` | `seo:` | Metadata, structured data, sitemap, feeds |
+| Content | `content` | `content:` | Blog prose, dead links, new writing |
+
+Other in-use labels: `ci`, `refactor`, `documentation`, `dependencies` (Dependabot).
+
 ## Pre-push checklist
 
 Mirror the blocking CI gates locally before opening a PR:


### PR DESCRIPTION
Closes #25 — scaffolds `.github/` so new issues and PRs land with structure.

## Added
- **`.github/ISSUE_TEMPLATE/`** — 7 templates: `bug`, `feat`, `chore`, `a11y`, `perf`, `seo`, `content`. Each applies its matching label and a conventional title prefix. `config.yml` keeps blank issues enabled and links the production-readiness manual.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary · test plan (with the verify/smoke checkboxes) · related issues, plus the no-AI-trailer reminder.
- **`CONTRIBUTING.md`** — a label-scheme table tying *type → label → prefix → branch → commit*, so a change reads the same from issue to log.

## Label scheme
All referenced labels already existed (`bug`, `enhancement`, `chore`, `accessibility`, `performance`, `seo`, `content`) — templates apply them exactly. I also filled in descriptions on the previously-bare labels so the scheme is self-documenting on GitHub.

## Verification
- `config.yml` + all 7 template frontmatter blocks validate (parsed with `yaml.safe_load`); each maps to an existing label.
- No `src/` changes, so the build is unaffected; `verify` will confirm.