### PR TITLE
ci: move archive:check to a weekly scheduled sweep (option b)

### DIFF
--- a/.github/workflows/archive-check.yml
+++ b/.github/workflows/archive-check.yml
@@ -1,0 +1,74 @@
+name: Weekly link check
+
+# Outbound-link rot is time-driven, not commit-driven, and the check is
+# network-dependent (flaky on transient failures). So it runs on a weekly
+# schedule instead of per-push. Only genuine 404/410 rot fails the run; bot
+# blocks (403/429), method errors, and timeouts are reported but ignored
+# (see scripts/archive-links.mjs). On failure it opens — or updates — a single
+# tracking issue with the dead-link list.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: archive-check
+  cancel-in-progress: false
+
+jobs:
+  archive-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check outbound links
+        id: check
+        run: |
+          set +e
+          npm run archive:check 2>&1 | tee archive-output.txt
+          echo "code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Open or update dead-link issue
+        if: steps.check.outputs.code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TITLE="🔗 Dead links detected by the weekly sweep"
+
+          # Extract the fenced dead-link list emitted by the script.
+          sed -n '/<<<DEAD_LINKS_START>>>/,/<<<DEAD_LINKS_END>>>/p' archive-output.txt \
+            | sed '1d;$d' > dead-links.txt
+
+          {
+            echo "The weekly link check found outbound links returning **404/410** (genuinely gone — bot-blocks and timeouts are excluded)."
+            echo
+            echo "_Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} · $(date -u +%Y-%m-%d)_"
+            echo
+            cat dead-links.txt
+            echo
+            echo "These live in post bodies — fix or remove per the content fast-path in CONTRIBUTING.md. Close this issue once resolved; the next sweep reopens it if any remain."
+          } > issue-body.md
+
+          EXISTING=$(gh issue list --state open --search "in:title $TITLE" --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file issue-body.md
+            echo "Commented on existing issue #$EXISTING."
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md --label content --label chore
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,9 +112,11 @@ jobs:
   # lets the workflow run pass even if this job goes red, and `audit` is not a
   # required status check on `main` (only `verify` is). The individual steps
   # deliberately do NOT use step-level continue-on-error — that would mask a
-  # budget/link/cross-browser regression as a green check and kill the loud
-  # signal. `if: ${{ !cancelled() }}` keeps every advisory step running and
-  # reporting its true status regardless of an earlier advisory failure.
+  # budget/cross-browser regression as a green check and kill the loud signal.
+  # `if: ${{ !cancelled() }}` keeps every advisory step running and reporting its
+  # true status regardless of an earlier advisory failure. (Outbound-link rot is
+  # checked weekly in archive-check.yml, not here — it's time-driven, not
+  # commit-driven.)
   audit:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -139,10 +141,6 @@ jobs:
         with:
           uploadArtifacts: true
           configPath: ./lighthouserc.json
-
-      - name: Archive link check (advisory)
-        if: ${{ !cancelled() }}
-        run: npm run archive:check
 
       - name: Install Playwright (firefox + webkit)
         if: ${{ !cancelled() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,19 @@ reads the same from issue to branch to PR to log.
 
 Other in-use labels: `ci`, `refactor`, `documentation`, `dependencies` (Dependabot).
 
+## Outbound-link checking (weekly, not per-push)
+
+Dead-link rot is time-driven, not commit-driven, and the check hits the network
+for every outbound URL (flaky on transient failures). So `archive:check` runs on
+a **weekly schedule** (`.github/workflows/archive-check.yml`, Mondays), not in
+the per-push pipeline. Only genuine **404/410** rot fails the run; bot-blocks
+(403/429), method errors, and timeouts are reported but ignored. On failure the
+workflow opens — or updates — a single tracking issue with the dead-link list.
+
+Run it yourself anytime with `npm run archive:check` (read-only) or trigger the
+workflow manually from the Actions tab. `npm run archive` (no flag) additionally
+saves new Wayback snapshots and is a local/manual op.
+
 ## Pre-push checklist
 
 Mirror the blocking CI gates locally before opening a PR:

--- a/scripts/archive-links.mjs
+++ b/scripts/archive-links.mjs
@@ -217,6 +217,7 @@ async function main() {
   let blocked = 0;
   let unknown = 0;
   let newlyArchived = 0;
+  const deadUrls = [];
 
   for (const url of urls) {
     const existing = archive[url] || {};
@@ -235,6 +236,7 @@ async function main() {
 
     if (result.state === "dead") {
       dead++;
+      deadUrls.push({ url, code: result.code });
       process.stdout.write(`    ✗ DEAD (${result.code})\n`);
     } else if (result.state === "alive") {
       process.stdout.write(`    ✓ alive\n`);
@@ -300,6 +302,14 @@ async function main() {
   console.log(`  Inconclusive — timeout/DNS (not dead): ${unknown}`);
   console.log(`  Newly archived: ${newlyArchived}`);
   console.log(`  Total archived: ${Object.values(archive).filter((e) => e.archived).length}/${urls.length}`);
+
+  // Machine-readable dead-link list, fenced with stable markers so the weekly
+  // workflow (archive-check.yml) can extract it into a GitHub issue body.
+  if (deadUrls.length > 0) {
+    console.log("\n<<<DEAD_LINKS_START>>>");
+    for (const { url, code } of deadUrls) console.log(`- ${url} (HTTP ${code})`);
+    console.log("<<<DEAD_LINKS_END>>>");
+  }
 
   // Only genuine rot (404/410) fails the check. Bot-blocks and transient
   // errors are reported above but never break CI — that was the false-positive


### PR DESCRIPTION
Closes #29 — decides and implements the `archive:check` cadence.

## Decision: weekly cron + issue-on-failure (option b)
Outbound-link rot is **time-driven, not commit-driven**, and the check hits the network for every URL (flaky on transient failures). Running it on every push was pure noise that slowed PRs. Now that the checker only flags genuine 404/410 (PR #68), a scheduled sweep is trustworthy.

## Changes
- **Removed** the archive-link step from the per-push `audit` job in `deploy.yml`.
- **Added** `.github/workflows/archive-check.yml`: weekly cron (Mondays 06:00 UTC) + `workflow_dispatch`. Only genuine **404/410** fails the run; bot-blocks/timeouts are reported but ignored. On failure it **opens — or updates — a single tracking issue** with the dead-link list (labels: `content`, `chore`).
- **`archive-links.mjs`** emits a fenced `<<<DEAD_LINKS_START>>>…<<<DEAD_LINKS_END>>>` block so the workflow extracts the list cleanly into the issue body.
- **`CONTRIBUTING.md`** documents the cadence and how to run it manually.

## Verification
- Script syntax (`node --check`) and both workflow YAMLs validate.
- Dead-link extraction (`sed` between markers) verified against a sample.
- The cron's issue path can be exercised on demand via the Actions "Run workflow" button after merge.