### PR TITLE
refactor(css): offset-driven neu utilities + documented pattern (#15)

### DIFF
--- a/docs/SITE_NOTES.md
+++ b/docs/SITE_NOTES.md
@@ -45,6 +45,26 @@ outsourced to icon packs, gradients, and stock blobs.
 This is not minimalism for its own sake. Text is fast, inspectable, and hard to
 fake into looking like every other portfolio template.
 
+### Neubrutalist surfaces
+
+The thick-border + hard offset-shadow (no `border-radius`) pattern is defined
+once in `global.css`. New surfaces should use those classes instead of
+copy-pasting `box-shadow: Npx Npx 0 var(--…)` into scoped styles — that
+copy-paste is what drifts as pages are added.
+
+- `.neu-box` / `.neu-box-sm` — bordered card with offset shadow + `--bg`.
+- `.neu-shadow-static` — resting offset shadow only (no border/background).
+- Size and colour are per-element custom properties, so a surface keeps its own
+  look while sharing the definition:
+  - `--neu-offset` — shadow offset (x = y), default `4px` (`3px` for `-sm`).
+  - `--neu-color` — shadow colour, default `--fg` (e.g. `--muted`, `--bg`).
+  - `--neu-border` — border width, default `3px`.
+  - e.g. `<div class="neu-box" style="--neu-offset: 8px; --neu-color: var(--muted)">`.
+- Interactive hover/active state shadows stay in the component's scoped styles —
+  they are per-component motion, not the shared resting pattern. The hover
+  helpers (`.neu-shadow`, `.neu-shadow-lg`, `.neu-pressed`) cover the common
+  lift/press transitions.
+
 ## Content
 
 Blog posts live in `src/content/blog/`. The renderer should make long-form

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -68,7 +68,7 @@ const jsonLd = JSON.stringify({
         </p>
         <p class="about-hero__meta">Lisbon Area &middot; EU&nbsp;Time&nbsp;Zones &middot; Open to&nbsp;opportunities</p>
       </div>
-      <div class="about-hero__photo">
+      <div class="about-hero__photo neu-box">
         <img
           src="/cool.webp"
           alt="Jonatan looking towards ten o'clock"
@@ -385,10 +385,9 @@ const jsonLd = JSON.stringify({
 
   /* ── Hero Photo, neubrutalist frame ── */
   .about-hero__photo {
+    /* frame + offset shadow provided by .neu-box; just set the offset */
+    --neu-offset: 6px;
     width: clamp(180px, 22vw, 280px);
-    border: 3px solid var(--fg);
-    box-shadow: 6px 6px 0 var(--fg);
-    background: var(--bg);
     padding: 6px;
     transform: rotate(1.5deg);
     transition: transform 0.2s ease, box-shadow 0.2s ease;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -240,18 +240,35 @@ a:hover {
 
 /* ── Neubrutalist Utilities ── */
 
-/* Base neu-box: thick border + offset shadow, no border-radius */
+/* Neubrutalist surface helpers.
+   The offset shadow and border are driven by per-element custom properties so a
+   component can keep its own size/colour while still sharing one definition:
+     --neu-offset : shadow offset (x = y), e.g. `style="--neu-offset: 8px"`
+     --neu-color  : shadow colour, defaults to --fg (e.g. --muted, --bg)
+     --neu-border : border width, defaults to 3px
+   Defaults reproduce the original hard-coded values, so existing markup is
+   visually unchanged. These are local helper vars, not theme tokens — the
+   6 theme variables in :root are still the only palette knobs. */
 .neu-box {
-  border: 3px solid var(--fg);
-  box-shadow: 4px 4px 0 var(--fg);
+  border: var(--neu-border, 3px) solid var(--fg);
+  box-shadow: var(--neu-offset, 4px) var(--neu-offset, 4px) 0 var(--neu-color, var(--fg));
   background: var(--bg);
 }
 
 /* Smaller variant for secondary/compact cards */
 .neu-box-sm {
-  border: 2px solid var(--fg);
-  box-shadow: 3px 3px 0 var(--fg);
+  --neu-border: 2px;
+  --neu-offset: 3px;
+  border: var(--neu-border) solid var(--fg);
+  box-shadow: var(--neu-offset) var(--neu-offset) 0 var(--neu-color, var(--fg));
   background: var(--bg);
+}
+
+/* Resting offset shadow only (no border/background). Override size/colour with
+   --neu-offset / --neu-color. For the bare `box-shadow: Npx Npx 0 var(--…)`
+   pattern that previously got copy-pasted into scoped styles. */
+.neu-shadow-static {
+  box-shadow: var(--neu-offset, 4px) var(--neu-offset, 4px) 0 var(--neu-color, var(--fg));
 }
 
 /* Base transition for any neu element that moves on hover */


### PR DESCRIPTION
Addresses #15 — the neubrutalist offset-shadow (`box-shadow: Npx Npx 0 var(--…)`) was copy-pasted across scoped style blocks, with drift risk as pages grow.

## Approach (per your pick: CSS-var utility)
Made the shared utilities flexible enough to absorb the per-component sizes via custom properties, rather than churning every intentional one-off.

- **`global.css`**: `.neu-box` / `.neu-box-sm` now drive border / offset / shadow-colour from `--neu-border` / `--neu-offset` / `--neu-color`, **defaults equal to the old hard-coded values** → existing markup renders pixel-identical. Added `.neu-shadow-static` for the bare resting-shadow case. These are *local helper vars*, not theme tokens — the 6 `:root` palette variables are untouched (locked invariant respected).
- **`about.astro`**: migrated `.about-hero__photo` → `.neu-box` + `--neu-offset: 6px` as the reference adoption.
- **`SITE_NOTES.md`**: documented the utility + `--neu-*` API so new surfaces use it instead of re-declaring the pattern (this is the durable fix for the drift the issue is about).

## Scope note
Interactive **hover/active** shadows (most of the inline occurrences) stay in scoped styles — they're per-component motion tightly coupled to each element's `transform`/`transition`, not the shared resting pattern, so forcing them into utilities would change behavior for no real dedup. The flexible utility + documented API prevents *future* drift; remaining resting one-offs can adopt `.neu-box`/`.neu-shadow-static` incrementally and risk-free.

## Verification
- **Pixel-diff of every page** (desktop + mobile), before vs after: **0 differing pixels** on all CSS-affected pages (only the 404 canvas snake-game animation differs, unrelated).
- `verify:local`: 0 errors · bundle 93.9 KB · smoke **62/62**.

Refs #15.