### PR TITLE
fix(social): stop the feed intermittently failing to load on first hit

### DIFF
--- a/src/lib/social-feed.ts
+++ b/src/lib/social-feed.ts
@@ -70,12 +70,21 @@ function isVisiblePost(post: Post): boolean {
 let prevAbort: AbortController | null = null;
 
 export function initSocialFeed() {
+  const feedEl = document.getElementById("social-feed");
+  if (!feedEl) return;
+
+  // Idempotency, per #social-feed element. On initial load both the immediate
+  // bootstrap call and the astro:page-load event fire — without this guard the
+  // second call aborts the first's in-flight fetch and starts its own, so a
+  // transient failure in that redundant fetch would clobber a feed that had
+  // already loaded (the intermittent "blank feed on first hit"). A client-side
+  // navigation swaps in a fresh element with no flag, so re-init still runs.
+  if (feedEl.dataset.feedInit === "1") return;
+  feedEl.dataset.feedInit = "1";
+
   prevAbort?.abort();
   prevAbort = new AbortController();
   const { signal } = prevAbort;
-
-  const feedEl = document.getElementById("social-feed");
-  if (!feedEl) return;
 
   const loadMoreEl = document.getElementById("social-load-more");
   const loadMoreBtn = document.getElementById("social-load-more-btn") as HTMLButtonElement | null;

--- a/src/pages/social.astro
+++ b/src/pages/social.astro
@@ -410,11 +410,21 @@ import StructuralArt from "../components/StructuralArt.astro";
 
   <script>
     import { initSocialFeed } from "../lib/social-feed";
-    document.addEventListener("astro:page-load", initSocialFeed);
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", initSocialFeed, { once: true });
-    } else {
-      initSocialFeed();
+    // Guard the bootstrap: this <script> re-executes on every Astro client-side
+    // navigation, so without a flag we'd stack a new astro:page-load listener
+    // (and an extra init) on each revisit. Register once; astro:page-load then
+    // drives re-init on every navigation, and the ready-state path covers the
+    // initial load if the event already fired before this ran. initSocialFeed
+    // is idempotent per #social-feed element, so the two initial-load paths
+    // can't double-fetch.
+    if (!(window as any).__socialFeedBootstrapped) {
+      (window as any).__socialFeedBootstrapped = true;
+      document.addEventListener("astro:page-load", initSocialFeed);
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", initSocialFeed, { once: true });
+      } else {
+        initSocialFeed();
+      }
     }
   </script>
 

--- a/tests/social-feed.spec.ts
+++ b/tests/social-feed.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+const TIMELINE = /social\.dotmavriq\.life\/api\/v1\/timelines\/public/;
+
+function samplePosts() {
+  return Array.from({ length: 20 }, (_, i) => ({
+    id: String(1000 - i),
+    url: `https://social.dotmavriq.life/notice/${1000 - i}`,
+    created_at: '2026-06-01T12:00:00.000Z',
+    content: `<p>sample post ${i}</p>`,
+    visibility: 'public',
+    account: { avatar: 'https://social.dotmavriq.life/avatar.png', display_name: 'dotmavriq', acct: 'dotmavriq' },
+    media_attachments: [],
+  }));
+}
+
+test('social feed renders on initial load with exactly one timeline request', async ({ page }) => {
+  let timelineCalls = 0;
+  await page.route(TIMELINE, async (route) => {
+    timelineCalls++;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(samplePosts()) });
+  });
+
+  await page.goto('/social');
+
+  // Feed must populate (this is the bug: it often stayed blank).
+  await expect(page.locator('#social-feed .social-post').first()).toBeVisible({ timeout: 8000 });
+  await expect(page.locator('#social-feed .social-post')).toHaveCount(20);
+
+  // No redundant double-init: the initial load must not fire two timeline fetches.
+  await page.waitForTimeout(600);
+  expect(timelineCalls, 'initial load should make exactly one timeline request').toBe(1);
+});
+
+test('a transient second init cannot clobber an already-loaded feed', async ({ page }) => {
+  await page.route(TIMELINE, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(samplePosts()) });
+  });
+  await page.goto('/social');
+  await expect(page.locator('#social-feed .social-post')).toHaveCount(20);
+
+  // Re-invoking the bootstrap (as a stray astro:page-load would) must be a no-op
+  // on the same element, not a re-fetch that could fail and blank the feed.
+  await page.evaluate(() => document.dispatchEvent(new Event('astro:page-load')));
+  await page.waitForTimeout(400);
+  await expect(page.locator('#social-feed .social-post')).toHaveCount(20);
+});


### PR DESCRIPTION
## The bug
`/social` often renders a blank/error feed on initial load from a browser. Two bootstrap defects, both in how `initSocialFeed` is wired:

1. **No bootstrap guard.** With `<ClientRouter />`, Astro re-executes the feed `<script>` on every client-side navigation, so it stacked a fresh `astro:page-load` listener each time → `initSocialFeed` fired N times per page-load. (The QR-welcome script immediately above already guards against exactly this; the feed script never got the same treatment.)
2. **`initSocialFeed` wasn't idempotent.** On initial load *both* the immediate bootstrap call and the `astro:page-load` event fire it. The second call `prevAbort.abort()`s the first's in-flight fetch and starts its own — so a **transient failure in that redundant second fetch clobbered a feed that had already loaded**. That's the intermittent blank feed.

## The fix
- **`social.astro`**: guard the bootstrap with `window.__socialFeedBootstrapped` so the listener registers once; `astro:page-load` then drives re-init per navigation, with the ready-state path covering the initial load.
- **`social-feed.ts`**: make `initSocialFeed` idempotent via a `data-feed-init` flag on `#social-feed`. A client-side navigation swaps in a fresh element (no flag), so re-init still runs; same-page double-calls are no-ops.

## Verification
New `tests/social-feed.spec.ts` (timeline API stubbed):
- feed renders on initial load with **exactly one** timeline request (was 2 → the clobber source);
- a stray `astro:page-load` re-init **cannot blank** an already-loaded feed.

`verify:local` 0 errors · bundle 94.0 KB · smoke **64/64**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed social feed initialization to prevent duplicate API requests during page navigation events.

* **Tests**
  * Added comprehensive test coverage for social feed rendering and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->